### PR TITLE
Refactor events and state handling

### DIFF
--- a/src/main/java/de/burger/it/application/cart/handler/OnCartActiveAssignCartStatus.java
+++ b/src/main/java/de/burger/it/application/cart/handler/OnCartActiveAssignCartStatus.java
@@ -15,6 +15,6 @@ public class OnCartActiveAssignCartStatus {
     }
 
     public void execute(CartActiveEvent event) {
-        cartStatusAssignmentPort.assign(event.cart(), CartStateType.ACTIVE);
+        cartStatusAssignmentPort.assign(event.getCart(), CartStateType.ACTIVE);
     }
 }

--- a/src/main/java/de/burger/it/application/cart/handler/OnCartCloseAssignCartStatus.java
+++ b/src/main/java/de/burger/it/application/cart/handler/OnCartCloseAssignCartStatus.java
@@ -15,6 +15,6 @@ public class OnCartCloseAssignCartStatus {
     }
 
     public void execute(CartCloseEvent event) {
-        cartStatusAssignmentPort.assign(event.cart(), CartStateType.CLOSED);
+        cartStatusAssignmentPort.assign(event.getCart(), CartStateType.CLOSED);
     }
 }

--- a/src/main/java/de/burger/it/application/cart/handler/OnCartCreateAssignCartStatus.java
+++ b/src/main/java/de/burger/it/application/cart/handler/OnCartCreateAssignCartStatus.java
@@ -15,6 +15,6 @@ public class OnCartCreateAssignCartStatus {
     }
 
     public void execute(CartCreateEvent event) {
-        cartStatusAssignmentPort.assign(event.cart(), CartStateType.CREATED);
+        cartStatusAssignmentPort.assign(event.getCart(), CartStateType.CREATED);
     }
 }

--- a/src/main/java/de/burger/it/application/cart/handler/OnCartCreateAssignCustomer.java
+++ b/src/main/java/de/burger/it/application/cart/handler/OnCartCreateAssignCustomer.java
@@ -14,6 +14,6 @@ public class OnCartCreateAssignCustomer {
     }
 
     public void execute(CartCreateEvent event) {
-        cartCustomerAssignmentPort.assign(event.cart(),event.customer());
+        cartCustomerAssignmentPort.assign(event.getCart(), event.getCustomer());
     }
 }

--- a/src/main/java/de/burger/it/application/cart/handler/OnCartCreateSaveRepository.java
+++ b/src/main/java/de/burger/it/application/cart/handler/OnCartCreateSaveRepository.java
@@ -13,6 +13,6 @@ public class OnCartCreateSaveRepository {
     }
 
     public void execute(CartCreateEvent event) {
-        cartRepository.save(event.cart());
+        cartRepository.save(event.getCart());
     }
 }

--- a/src/main/java/de/burger/it/application/cart/service/CartService.java
+++ b/src/main/java/de/burger/it/application/cart/service/CartService.java
@@ -9,6 +9,7 @@ import de.burger.it.domain.cart.model.NullCart;
 import de.burger.it.domain.cart.port.CartRepositoryPort;
 import de.burger.it.domain.cart.port.CartStatusAssignmentPort;
 import de.burger.it.domain.cart.state.CartState;
+import de.burger.it.domain.cart.state.NullCartState;
 import de.burger.it.domain.customer.model.Customer;
 import de.burger.it.domain.customer.model.CustomerLike;
 import de.burger.it.domain.relation.port.CartCustomerAssignmentPort;
@@ -86,11 +87,11 @@ public class CartService {
                 .toList();
     }
 
-    public List<CartLike> findAllCartByCarts(CartLike cart) {
+    public List<CartLike> findAllCartsByCart(CartLike cart) {
         if (cart.isNull()) {
             return Collections.emptyList();
         }
-        var cartCustomerAssignments = cartCustomerAssignmentPort.findAllByCard(cart.id());
+        var cartCustomerAssignments = cartCustomerAssignmentPort.findAllByCart(cart.id());
         return cartCustomerAssignments.stream()
                 .map(cartCustomerAssignment -> {
                     CartLike foundCart = cartRepository.findById(cartCustomerAssignment.cartId());
@@ -101,9 +102,10 @@ public class CartService {
 
     public CartState getState(CartLike cart) {
         if (cart.isNull()) {
-            return null; // Return null or a default state for NullCart
+            return NullCartState.getInstance();
         }
-        return cartStatusAssignmentPort.findBy(cart.id()).toState();
+        var stateType = cartStatusAssignmentPort.findBy(cart.id());
+        return stateType != null ? stateType.toState() : NullCartState.getInstance();
     }
 
 }

--- a/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateAssignActive.java
+++ b/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateAssignActive.java
@@ -15,6 +15,6 @@ public class OnCustomerCreateAssignActive {
     }
 
     public void execute(CustomerCreateEvent event) {
-        customerStatusAssignmentPort.assign(event.customer(), CustomerStateType.ACTIVE);
+        customerStatusAssignmentPort.assign(event.getCustomer(), CustomerStateType.ACTIVE);
     }
 }

--- a/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateNewCart.java
+++ b/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateNewCart.java
@@ -15,6 +15,6 @@ public class OnCustomerCreateNewCart {
     }
 
     public void execute(CustomerCreateEvent event) {
-        cartService.create(event.customer());
+        cartService.create(event.getCustomer());
     }
 }

--- a/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateSaveRepository.java
+++ b/src/main/java/de/burger/it/application/customer/handler/OnCustomerCreateSaveRepository.java
@@ -13,6 +13,6 @@ public class OnCustomerCreateSaveRepository {
     }
 
     public void execute(CustomerCreateEvent event) {
-        customerRepository.save(event.customer());
+        customerRepository.save(event.getCustomer());
     }
 }

--- a/src/main/java/de/burger/it/application/customer/handler/OnCustomerSuspendAssignSuspend.java
+++ b/src/main/java/de/burger/it/application/customer/handler/OnCustomerSuspendAssignSuspend.java
@@ -15,6 +15,6 @@ public class OnCustomerSuspendAssignSuspend {
     }
 
     public void execute(CustomerSuspendEvent event) {
-        customerStatusAssignmentPort.assign(event.customer(), CustomerStateType.SUSPENDED);
+        customerStatusAssignmentPort.assign(event.getCustomer(), CustomerStateType.SUSPENDED);
     }
 }

--- a/src/main/java/de/burger/it/application/event/EventProcessor.java
+++ b/src/main/java/de/burger/it/application/event/EventProcessor.java
@@ -41,7 +41,10 @@ public class EventProcessor<E> {
             return null;
         }
         
-        List<EventHandler<? extends E>> eventHandlers = handlers.getOrDefault(event.getClass(), List.of());
+        List<EventHandler<? extends E>> eventHandlers = handlers.entrySet().stream()
+                .filter(entry -> entry.getKey().isAssignableFrom(event.getClass()))
+                .flatMap(entry -> entry.getValue().stream())
+                .toList();
         T result = event;
         
         for (EventHandler<? extends E> handler : eventHandlers) {

--- a/src/main/java/de/burger/it/application/order/handler/OnOrderCancelAssignCanceledState.java
+++ b/src/main/java/de/burger/it/application/order/handler/OnOrderCancelAssignCanceledState.java
@@ -15,6 +15,6 @@ public class OnOrderCancelAssignCanceledState {
     }
 
     public void execute(OrderCancelEvent event) {
-        orderStatusAssignmentPort.assign(event.order(), OrderStateType.CANCELLED);
+        orderStatusAssignmentPort.assign(event.getOrder(), OrderStateType.CANCELLED);
     }
 }

--- a/src/main/java/de/burger/it/application/order/handler/OnOrderCreateAssignNewState.java
+++ b/src/main/java/de/burger/it/application/order/handler/OnOrderCreateAssignNewState.java
@@ -15,6 +15,6 @@ public class OnOrderCreateAssignNewState {
     }
 
     public void execute(OrderCreateEvent event) {
-        orderStatusAssignmentPort.assign(event.order(), OrderStateType.NEW);
+        orderStatusAssignmentPort.assign(event.getOrder(), OrderStateType.NEW);
     }
 }

--- a/src/main/java/de/burger/it/application/order/handler/OnOrderCreateSaveRepository.java
+++ b/src/main/java/de/burger/it/application/order/handler/OnOrderCreateSaveRepository.java
@@ -14,6 +14,6 @@ public class OnOrderCreateSaveRepository {
     }
 
     public void execute(OrderCreateEvent event) {
-        orderRepository.save(event.order());
+        orderRepository.save(event.getOrder());
     }
 }

--- a/src/main/java/de/burger/it/application/order/handler/OnOrderDeliverAssignDeliveredState.java
+++ b/src/main/java/de/burger/it/application/order/handler/OnOrderDeliverAssignDeliveredState.java
@@ -15,6 +15,6 @@ public class OnOrderDeliverAssignDeliveredState {
     }
 
     public void execute(OrderDeliverEvent event) {
-        orderStatusAssignmentPort.assign(event.order(), OrderStateType.DELIVERED);
+        orderStatusAssignmentPort.assign(event.getOrder(), OrderStateType.DELIVERED);
     }
 }

--- a/src/main/java/de/burger/it/application/order/handler/OnOrderPayAssignPaidState.java
+++ b/src/main/java/de/burger/it/application/order/handler/OnOrderPayAssignPaidState.java
@@ -15,6 +15,6 @@ public class OnOrderPayAssignPaidState {
     }
 
     public void execute(OrderPayEvent event) {
-        orderStatusAssignmentPort.assign(event.order(), OrderStateType.PAID);
+        orderStatusAssignmentPort.assign(event.getOrder(), OrderStateType.PAID);
     }
 }

--- a/src/main/java/de/burger/it/domain/cart/event/CartActiveEvent.java
+++ b/src/main/java/de/burger/it/domain/cart/event/CartActiveEvent.java
@@ -2,6 +2,26 @@ package de.burger.it.domain.cart.event;
 
 import de.burger.it.domain.cart.model.Cart;
 import de.burger.it.domain.customer.model.Customer;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record CartActiveEvent(Cart cart, Customer customer) {
+/**
+ * Event fired when a cart becomes active.
+ */
+public class CartActiveEvent extends DomainEvent {
+
+    private final Cart cart;
+    private final Customer customer;
+
+    public CartActiveEvent(Cart cart, Customer customer) {
+        this.cart = cart;
+        this.customer = customer;
+    }
+
+    public Cart getCart() {
+        return cart;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
 }

--- a/src/main/java/de/burger/it/domain/cart/event/CartCloseEvent.java
+++ b/src/main/java/de/burger/it/domain/cart/event/CartCloseEvent.java
@@ -2,6 +2,26 @@ package de.burger.it.domain.cart.event;
 
 import de.burger.it.domain.cart.model.Cart;
 import de.burger.it.domain.customer.model.Customer;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record CartCloseEvent (Cart cart, Customer customer) {
+/**
+ * Event fired when a cart is closed.
+ */
+public class CartCloseEvent extends DomainEvent {
+
+    private final Cart cart;
+    private final Customer customer;
+
+    public CartCloseEvent(Cart cart, Customer customer) {
+        this.cart = cart;
+        this.customer = customer;
+    }
+
+    public Cart getCart() {
+        return cart;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
 }

--- a/src/main/java/de/burger/it/domain/cart/event/CartCreateEvent.java
+++ b/src/main/java/de/burger/it/domain/cart/event/CartCreateEvent.java
@@ -2,6 +2,26 @@ package de.burger.it.domain.cart.event;
 
 import de.burger.it.domain.cart.model.Cart;
 import de.burger.it.domain.customer.model.Customer;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record CartCreateEvent(Cart cart, Customer customer) {
+/**
+ * Event fired whenever a new cart is created for a customer.
+ */
+public class CartCreateEvent extends DomainEvent {
+
+    private final Cart cart;
+    private final Customer customer;
+
+    public CartCreateEvent(Cart cart, Customer customer) {
+        this.cart = cart;
+        this.customer = customer;
+    }
+
+    public Cart getCart() {
+        return cart;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
 }

--- a/src/main/java/de/burger/it/domain/cart/model/Cart.java
+++ b/src/main/java/de/burger/it/domain/cart/model/Cart.java
@@ -3,6 +3,12 @@ package de.burger.it.domain.cart.model;
 import java.util.UUID;
 
 public record Cart(UUID id) implements CartLike {
+
+    public Cart {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null");
+        }
+    }
     
     @Override
     public boolean isNull() {

--- a/src/main/java/de/burger/it/domain/cart/state/NullCartState.java
+++ b/src/main/java/de/burger/it/domain/cart/state/NullCartState.java
@@ -1,0 +1,42 @@
+package de.burger.it.domain.cart.state;
+
+/**
+ * Null object implementation for {@link CartState}.
+ * Used when no real cart state is available.
+ */
+public final class NullCartState implements CartState {
+
+    private static final NullCartState INSTANCE = new NullCartState();
+
+    private NullCartState() {
+    }
+
+    public static NullCartState getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public CartState create() {
+        return this;
+    }
+
+    @Override
+    public CartState activate() {
+        return this;
+    }
+
+    @Override
+    public CartState order() {
+        return this;
+    }
+
+    @Override
+    public CartState close() {
+        return this;
+    }
+
+    @Override
+    public CartStateType code() {
+        return CartStateType.CREATED;
+    }
+}

--- a/src/main/java/de/burger/it/domain/customer/event/CustomerCreateEvent.java
+++ b/src/main/java/de/burger/it/domain/customer/event/CustomerCreateEvent.java
@@ -1,5 +1,20 @@
 package de.burger.it.domain.customer.event;
 
 import de.burger.it.domain.customer.model.Customer;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record CustomerCreateEvent (Customer customer) { }
+/**
+ * Event emitted when a new customer is created.
+ */
+public class CustomerCreateEvent extends DomainEvent {
+
+    private final Customer customer;
+
+    public CustomerCreateEvent(Customer customer) {
+        this.customer = customer;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
+}

--- a/src/main/java/de/burger/it/domain/customer/event/CustomerSuspendEvent.java
+++ b/src/main/java/de/burger/it/domain/customer/event/CustomerSuspendEvent.java
@@ -1,6 +1,20 @@
 package de.burger.it.domain.customer.event;
 
 import de.burger.it.domain.customer.model.Customer;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record CustomerSuspendEvent(Customer customer) {
+/**
+ * Event emitted when a customer is suspended.
+ */
+public class CustomerSuspendEvent extends DomainEvent {
+
+    private final Customer customer;
+
+    public CustomerSuspendEvent(Customer customer) {
+        this.customer = customer;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
 }

--- a/src/main/java/de/burger/it/domain/customer/model/Customer.java
+++ b/src/main/java/de/burger/it/domain/customer/model/Customer.java
@@ -3,6 +3,18 @@ package de.burger.it.domain.customer.model;
 import java.util.UUID;
 
 public record Customer(UUID id, String name, String email) implements CustomerLike {
+
+    public Customer {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name cannot be null or blank");
+        }
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("email cannot be null or blank");
+        }
+    }
     
     @Override
     public boolean isNull() {

--- a/src/main/java/de/burger/it/domain/customer/state/NullCustomerState.java
+++ b/src/main/java/de/burger/it/domain/customer/state/NullCustomerState.java
@@ -1,0 +1,36 @@
+package de.burger.it.domain.customer.state;
+
+/**
+ * Null object implementation for {@link CustomerState}.
+ */
+public final class NullCustomerState implements CustomerState {
+
+    private static final NullCustomerState INSTANCE = new NullCustomerState();
+
+    private NullCustomerState() {
+    }
+
+    public static NullCustomerState getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public CustomerState create() {
+        return this;
+    }
+
+    @Override
+    public CustomerState suspend() {
+        return this;
+    }
+
+    @Override
+    public CustomerState active() {
+        return this;
+    }
+
+    @Override
+    public CustomerStateType code() {
+        return CustomerStateType.CREATE;
+    }
+}

--- a/src/main/java/de/burger/it/domain/order/event/OrderCancelEvent.java
+++ b/src/main/java/de/burger/it/domain/order/event/OrderCancelEvent.java
@@ -1,5 +1,20 @@
 package de.burger.it.domain.order.event;
 
 import de.burger.it.domain.order.model.Order;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record OrderCancelEvent(Order order) { }
+/**
+ * Event emitted when an order is cancelled.
+ */
+public class OrderCancelEvent extends DomainEvent {
+
+    private final Order order;
+
+    public OrderCancelEvent(Order order) {
+        this.order = order;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/de/burger/it/domain/order/event/OrderCreateEvent.java
+++ b/src/main/java/de/burger/it/domain/order/event/OrderCreateEvent.java
@@ -1,5 +1,20 @@
 package de.burger.it.domain.order.event;
 
 import de.burger.it.domain.order.model.Order;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record OrderCreateEvent(Order order) { }
+/**
+ * Event emitted when a new order is created.
+ */
+public class OrderCreateEvent extends DomainEvent {
+
+    private final Order order;
+
+    public OrderCreateEvent(Order order) {
+        this.order = order;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/de/burger/it/domain/order/event/OrderDeliverEvent.java
+++ b/src/main/java/de/burger/it/domain/order/event/OrderDeliverEvent.java
@@ -1,5 +1,20 @@
 package de.burger.it.domain.order.event;
 
 import de.burger.it.domain.order.model.Order;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record OrderDeliverEvent(Order order) { }
+/**
+ * Event emitted when an order is delivered.
+ */
+public class OrderDeliverEvent extends DomainEvent {
+
+    private final Order order;
+
+    public OrderDeliverEvent(Order order) {
+        this.order = order;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/de/burger/it/domain/order/event/OrderPayEvent.java
+++ b/src/main/java/de/burger/it/domain/order/event/OrderPayEvent.java
@@ -1,5 +1,20 @@
 package de.burger.it.domain.order.event;
 
 import de.burger.it.domain.order.model.Order;
+import de.burger.it.domain.common.event.DomainEvent;
 
-public record OrderPayEvent(Order order) { }
+/**
+ * Event emitted when an order is paid.
+ */
+public class OrderPayEvent extends DomainEvent {
+
+    private final Order order;
+
+    public OrderPayEvent(Order order) {
+        this.order = order;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/de/burger/it/domain/relation/port/CartCustomerAssignmentPort.java
+++ b/src/main/java/de/burger/it/domain/relation/port/CartCustomerAssignmentPort.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface CartCustomerAssignmentPort {
-    List<CartCustomerAssignment> findAllByCard(UUID cartId);
+    List<CartCustomerAssignment> findAllByCart(UUID cartId);
     List<CartCustomerAssignment> findAllByCustomer(UUID customerId);
     void assign(Cart cart, Customer customer);
 }

--- a/src/main/java/de/burger/it/infrastructure/cart/adapter/CartStatusAssignmentAdapter.java
+++ b/src/main/java/de/burger/it/infrastructure/cart/adapter/CartStatusAssignmentAdapter.java
@@ -4,7 +4,6 @@ import de.burger.it.domain.cart.model.Cart;
 import de.burger.it.domain.cart.model.CartStatusAssignment;
 import de.burger.it.domain.cart.port.CartStatusAssignmentPort;
 import de.burger.it.domain.cart.state.CartStateType;
-import lombok.Data;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -12,7 +11,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Data
 @Component
 public class CartStatusAssignmentAdapter implements CartStatusAssignmentPort {
     private final Map<UUID, CartStatusAssignment> store = new ConcurrentHashMap<>();
@@ -39,6 +37,7 @@ public class CartStatusAssignmentAdapter implements CartStatusAssignmentPort {
         if (cartId == null) {
             throw new IllegalArgumentException("Cart ID cannot be null");
         }
-        return store.get(cartId).state();
+        CartStatusAssignment assignment = store.get(cartId);
+        return assignment != null ? assignment.state() : null;
     }
 }

--- a/src/main/java/de/burger/it/infrastructure/customer/adapter/CustomerStatusAssignmentAdapter.java
+++ b/src/main/java/de/burger/it/infrastructure/customer/adapter/CustomerStatusAssignmentAdapter.java
@@ -20,7 +20,8 @@ public class CustomerStatusAssignmentAdapter implements CustomerStatusAssignment
         if (customerId == null) {
             throw new IllegalArgumentException("Customer ID cannot be null");
         }
-        return store.get(customerId).state();
+        CustomerStatusAssignment assignment = store.get(customerId);
+        return assignment != null ? assignment.state() : null;
     }
 
     @Override

--- a/src/main/java/de/burger/it/infrastructure/order/adapter/OrderStatusAssignmentAdapter.java
+++ b/src/main/java/de/burger/it/infrastructure/order/adapter/OrderStatusAssignmentAdapter.java
@@ -20,7 +20,8 @@ public class OrderStatusAssignmentAdapter implements OrderStatusAssignmentPort {
         if (orderId == null) {
             throw new IllegalArgumentException("Order ID cannot be null");
         }
-        return store.get(orderId).state();
+        OrderStatusAssignment assignment = store.get(orderId);
+        return assignment != null ? assignment.state() : null;
     }
 
     @Override

--- a/src/main/java/de/burger/it/infrastructure/relation/adapter/CartCustomerAssignmentAdapter.java
+++ b/src/main/java/de/burger/it/infrastructure/relation/adapter/CartCustomerAssignmentAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 @Component
@@ -27,11 +28,11 @@ public class CartCustomerAssignmentAdapter implements CartCustomerAssignmentPort
                 cart.id(),
                 customer.id()
         );
-        store.computeIfAbsent(assignment.customerId(), k -> new ArrayList<>()).add(assignment);
+        store.computeIfAbsent(assignment.customerId(), k -> new CopyOnWriteArrayList<>()).add(assignment);
     }
 
     @Override
-    public List<CartCustomerAssignment> findAllByCard(UUID cartId) {
+    public List<CartCustomerAssignment> findAllByCart(UUID cartId) {
         if (cartId == null) {
             throw new IllegalArgumentException("Cart ID cannot be null");
         }

--- a/src/test/java/de/burger/it/application/cart/service/CartServiceTest.java
+++ b/src/test/java/de/burger/it/application/cart/service/CartServiceTest.java
@@ -10,6 +10,7 @@ import de.burger.it.domain.cart.port.CartRepositoryPort;
 import de.burger.it.domain.cart.port.CartStatusAssignmentPort;
 import de.burger.it.domain.cart.state.CartState;
 import de.burger.it.domain.cart.state.CartStateType;
+import de.burger.it.domain.cart.state.NullCartState;
 import de.burger.it.domain.customer.model.Customer;
 import de.burger.it.domain.customer.model.NullCustomer;
 import de.burger.it.domain.relation.model.CartCustomerAssignment;
@@ -118,21 +119,21 @@ class CartServiceTest {
     }
 
     @Test
-    void findAllCartByCarts_shouldReturnCartsForCart() {
+    void findAllCartsByCart_shouldReturnCartsForCart() {
         // Given
         UUID cartId = cart.id();
         CartCustomerAssignment assignment = new CartCustomerAssignment(cartId, customer.id());
         
-        when(cartCustomerAssignmentPort.findAllByCard(cartId)).thenReturn(List.of(assignment));
+        when(cartCustomerAssignmentPort.findAllByCart(cartId)).thenReturn(List.of(assignment));
         when(cartRepository.findById(cartId)).thenReturn(cart);
 
         // When
-        List<CartLike> result = cartService.findAllCartByCarts(cart);
+        List<CartLike> result = cartService.findAllCartsByCart(cart);
 
         // Then
         assertEquals(1, result.size());
         assertEquals(cart, result.getFirst());
-        verify(cartCustomerAssignmentPort).findAllByCard(cartId);
+        verify(cartCustomerAssignmentPort).findAllByCart(cartId);
         verify(cartRepository).findById(cartId);
     }
 
@@ -225,9 +226,9 @@ class CartServiceTest {
     }
 
     @Test
-    void findAllCartByCarts_whenCartIsNull_shouldReturnEmptyList() {
+    void findAllCartsByCart_whenCartIsNull_shouldReturnEmptyList() {
         // When
-        List<CartLike> result = cartService.findAllCartByCarts(NullCart.getInstance());
+        List<CartLike> result = cartService.findAllCartsByCart(NullCart.getInstance());
 
         // Then
         assertTrue(result.isEmpty());
@@ -235,12 +236,12 @@ class CartServiceTest {
     }
 
     @Test
-    void getState_whenCartIsNull_shouldReturnNull() {
+    void getState_whenCartIsNull_shouldReturnNullState() {
         // When
         CartState result = cartService.getState(NullCart.getInstance());
 
         // Then
-        assertNull(result);
+        assertEquals(NullCartState.getInstance(), result);
         verifyNoInteractions(cartStatusAssignmentPort);
     }
 

--- a/src/test/java/de/burger/it/infrastructure/cart/adapter/CartStatusAssignmentAdapterTest.java
+++ b/src/test/java/de/burger/it/infrastructure/cart/adapter/CartStatusAssignmentAdapterTest.java
@@ -81,8 +81,11 @@ class CartStatusAssignmentAdapterTest {
     }
 
     @Test
-    void findBy_whenCartIdNotFound_shouldThrowException() {
-        // When/Then
-        assertThrows(NullPointerException.class, () -> adapter.findBy(UUID.randomUUID()));
+    void findBy_whenCartIdNotFound_shouldReturnNull() {
+        // When
+        CartStateType state = adapter.findBy(UUID.randomUUID());
+
+        // Then
+        assertNull(state);
     }
 }

--- a/src/test/java/de/burger/it/infrastructure/customer/adapter/CustomerStatusAssignmentAdapterTest.java
+++ b/src/test/java/de/burger/it/infrastructure/customer/adapter/CustomerStatusAssignmentAdapterTest.java
@@ -81,8 +81,11 @@ class CustomerStatusAssignmentAdapterTest {
     }
 
     @Test
-    void findBy_whenCustomerIdNotFound_shouldThrowException() {
-        // When/Then
-        assertThrows(NullPointerException.class, () -> adapter.findBy(UUID.randomUUID()));
+    void findBy_whenCustomerIdNotFound_shouldReturnNull() {
+        // When
+        CustomerStateType state = adapter.findBy(UUID.randomUUID());
+
+        // Then
+        assertNull(state);
     }
 }

--- a/src/test/java/de/burger/it/infrastructure/order/adapter/OrderStatusAssignmentAdapterTest.java
+++ b/src/test/java/de/burger/it/infrastructure/order/adapter/OrderStatusAssignmentAdapterTest.java
@@ -81,8 +81,11 @@ class OrderStatusAssignmentAdapterTest {
     }
 
     @Test
-    void findBy_whenOrderIdNotFound_shouldThrowException() {
-        // When/Then
-        assertThrows(NullPointerException.class, () -> adapter.findBy(UUID.randomUUID()));
+    void findBy_whenOrderIdNotFound_shouldReturnNull() {
+        // When
+        OrderStateType state = adapter.findBy(UUID.randomUUID());
+
+        // Then
+        assertNull(state);
     }
 }

--- a/src/test/java/de/burger/it/infrastructure/relation/adapter/CartCustomerAssignmentAdapterTest.java
+++ b/src/test/java/de/burger/it/infrastructure/relation/adapter/CartCustomerAssignmentAdapterTest.java
@@ -43,12 +43,12 @@ class CartCustomerAssignmentAdapterTest {
     }
 
     @Test
-    void findAllByCard_shouldReturnAssignmentsForCart() {
+    void findAllByCart_shouldReturnAssignmentsForCart() {
         // Given
         adapter.assign(cart, customer);
         
         // When
-        List<CartCustomerAssignment> assignments = adapter.findAllByCard(cartId);
+        List<CartCustomerAssignment> assignments = adapter.findAllByCart(cartId);
         
         // Then
         assertEquals(1, assignments.size());
@@ -87,10 +87,10 @@ class CartCustomerAssignmentAdapterTest {
     // RedPath Tests
 
     @Test
-    void findAllByCard_whenCartIdIsNull_shouldThrowException() {
+    void findAllByCart_whenCartIdIsNull_shouldThrowException() {
         // When/Then
         // Verify that some exception is thrown when passing null
-        assertThrows(Exception.class, () -> adapter.findAllByCard(null));
+        assertThrows(Exception.class, () -> adapter.findAllByCart(null));
     }
 
     @Test
@@ -115,9 +115,9 @@ class CartCustomerAssignmentAdapterTest {
     }
 
     @Test
-    void findAllByCard_whenNoAssignmentsExist_shouldReturnEmptyList() {
+    void findAllByCart_whenNoAssignmentsExist_shouldReturnEmptyList() {
         // When
-        List<CartCustomerAssignment> assignments = adapter.findAllByCard(UUID.randomUUID());
+        List<CartCustomerAssignment> assignments = adapter.findAllByCart(UUID.randomUUID());
         
         // Then
         assertTrue(assignments.isEmpty());


### PR DESCRIPTION
## Summary
- standardise domain events on `DomainEvent`
- harden assignment adapters and relation mapping
- add null-object states and enforce validation

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688e11c176e0832686d888dfca42d8d5